### PR TITLE
🔧 Configure PyUp bot to run monthly; prefix emoji

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,0 +1,6 @@
+update: all
+pin: True
+branch: development
+schedule: "every month"
+branch_prefix: update/
+pr_prefix: "❗️ "

--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,12 @@ Latest Release: |Version|
 
 Compatibility: |Implementation| |Python| |License|
 
-Tests: |Build| |Coverage| |Requirements|
+Tests: |Build| |Coverage| |PyUp| |Requirements|
 
 .. |Version| image:: http://img.shields.io/pypi/v/MarkdownSuperscript.svg
         :target: https://pypi.python.org/pypi/MarkdownSuperscript/
         :alt: PyPI Version
+
 
 .. |Implementation| image:: https://img.shields.io/pypi/implementation/MarkdownSuperscript.svg
         :target: https://pypi.python.org/pypi/MarkdownSuperscript/
@@ -27,6 +28,10 @@ Tests: |Build| |Coverage| |Requirements|
 .. |Coverage| image:: https://img.shields.io/coveralls/jambonrose/markdown_superscript_extension.svg
         :target: https://coveralls.io/r/jambonrose/markdown_superscript_extension
         :alt: Coverage Status
+
+.. |PyUp| image:: https://pyup.io/repos/github/jambonrose/markdown_superscript_extension/shield.svg
+        :target: https://pyup.io/repos/github/jambonrose/markdown_superscript_extension/
+        :alt: Updates
 
 .. |Requirements| image:: https://requires.io/github/jambonrose/markdown_superscript_extension/requirements.svg?branch=development
         :target: https://requires.io/github/jambonrose/markdown_superscript_extension/requirements/?branch=development


### PR DESCRIPTION
The PyUp bot currently runs with defaults: as soon as a new package is updated, the bot opens a new PR. Given the size and stability of this package, that's overkill and takes up more of my time (multiple PRs when we could use one).

This update limits the bot to a monthly schedule. We also configure the bot to prefix pull-requests with an emoji. For reasons.