### PR TITLE
Enable short name via entrypoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,15 @@ check:
 	python setup.py check
 
 clean:
-	find . -name "*.pyc" -delete
-	find . -name "__pycache__" -delete
 	rm -rf *.egg-info
 	rm -rf .coverage
+	rm -rf .eggs
+	rm -rf .pytest_cache
 	rm -rf .tox
 	rm -rf build
 	rm -rf dist
+	find . -name "*.pyc" -delete
+	find . -name "__pycache__" -delete
 
 dist:
 	python setup.py sdist --formats=gztar bdist_wheel

--- a/requirements/dev_requirements.txt
+++ b/requirements/dev_requirements.txt
@@ -1,6 +1,6 @@
 bumpversion==0.5.3
 pre-commit==1.11.1
 setuptools==40.4.3
-tox==3.4.0
+tox==3.5.2
 twine==1.12.1
 wheel==0.32.1

--- a/setup.py
+++ b/setup.py
@@ -9,24 +9,34 @@
 
 from codecs import open as codec_open
 from distutils.command.check import check as CheckCommand  # noqa: N812
-from os import path
+from os.path import abspath, dirname, join
 from sys import argv
 
 from setuptools import setup
 
-HERE = path.abspath(path.dirname(__file__))
+HERE = abspath(dirname(__file__))
+
+
+def load_file_contents(file_path, as_list=True):
+    """Load file as string or list"""
+    abs_file_path = join(HERE, file_path)
+    with codec_open(abs_file_path, encoding="utf-8") as file_pointer:
+        if as_list:
+            return file_pointer.read().splitlines()
+        return file_pointer.read()
 
 
 # Get the long description from the Read Me
-with codec_open(path.join(HERE, "README.rst"), encoding="utf-8") as f:
-    long_description = f.read()
+LONG_DESCRIPTION = (
+    load_file_contents("README.rst", as_list=False)
+    .split(".. start-pypi-description")[1]  # remove badge icons and title
+    .lstrip()  # remove any extraneous spaces before title
+)
 
 # Get test dependencies
-test_reqs = "requirements/test_requirements.txt"
-with codec_open(path.join(HERE, test_reqs), encoding="utf-8") as f:
-    tests_require = f.read().splitlines()
+TESTS_REQUIRE = load_file_contents("requirements/test_requirements.txt")
 
-setup_requires_pytest_runner = (
+SETUP_REQUIRES_PYTEST_RUNNER = (
     ["pytest-runner>=4.2,<5"]
     if {"pytest", "test", "ptr"}.intersection(argv)
     else []
@@ -117,15 +127,27 @@ setup(
     version="2.1.0",  # PEP 440 Compliant Semantic Versioning
     keywords=["text", "filter", "markdown", "html", "superscript"],
     description="Python-Markdown extension to allow for superscript text.",
-    long_description=long_description,
+    long_description=LONG_DESCRIPTION,
     author="Andrew Pinkham",
     url="https://github.com/jambonrose/markdown_superscript_extension",
+    project_urls={
+        "Documentation": (
+            "https://markdown-superscript-extension.rtfd.io/en/stable/"
+        ),
+        "Source": (
+            "https://github.com/jambonrose/markdown_superscript_extension"
+        ),
+        "Tracker": (
+            "https://github.com/jambonrose/"
+            "markdown_superscript_extension/issues"
+        ),
+    },
     cmdclass={"check": CustomCheckCommand},
     py_modules=["mdx_superscript"],
     install_requires=["Markdown>=2.5,<3.1"],
     test_suite="tests",
-    tests_require=tests_require,
-    setup_requires=setup_requires_pytest_runner,
+    tests_require=TESTS_REQUIRE,
+    setup_requires=SETUP_REQUIRES_PYTEST_RUNNER,
     license="Simplified BSD License",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -147,4 +169,9 @@ setup(
         "Topic :: Text Processing :: Filters",
         "Topic :: Text Processing :: Markup :: HTML",
     ],
+    entry_points={
+        "markdown.extensions": [
+            "superscript = mdx_superscript:SuperscriptExtension"
+        ]
+    },
 )

--- a/tests/test_superscript.py
+++ b/tests/test_superscript.py
@@ -39,14 +39,7 @@ TEXT_DATA = [
             ),
             id="Full module name",
         ),
-        param(
-            ["superscript"],
-            marks=mark.skipif(
-                md_version >= (3, 0),
-                reason="Module matching by shortname removed in Markdown 3.0",
-            ),
-            id="Short module name",
-        ),
+        param(["superscript"], id="Short module name"),
     ],
 )
 def extensions(request):


### PR DESCRIPTION
Markdown's behavior pre-v3 was to automatically append `mdx_` to strings that acted as references to third-party extensions. Starting in Markdown v3, this behavior has been removed. In v2.1.0 of this package, we therefore lost the ability to refer to `superscript` (forcing developers to switch to `mdx_superscript`) if referring to the extension by string.

As it turns out, we can re-enable the old behavior by using an entrypoint in `setup.py`. This PR therefore re-enables previous behavior.