### PR TITLE
🚀 Release v2.1.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.0
+current_version = 2.1.1
 commit = True
 tag = False
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,9 @@ before_script:
 - pip freeze
 script:
 - if [[ `python -V | grep -c -e 3.7` -eq 1 && "$MD_VERSION" == '3.0' ]]; then flake8 . ; fi
-- if [[ `python -V | grep -c -e 3.6` -eq 1 && "$MD_VERSION" == '3.0' ]]; then cd docs && sphinx-build -W -b html -d _build/doctrees . _build/html; cd .. ; fi
+- cd docs
+- if [[ `python -V | grep -c -e 3.6` -eq 1 && "$MD_VERSION" == '3.0' ]]; then sphinx-build -W -b html -d _build/doctrees . _build/html ; fi
+- cd ..
 - pytest -v --cov --cov-report term-missing
 after_success:
 - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ matrix:
     dist: xenial
 install:
 - if [[ `python -V | grep -c -e 3.7` -eq 1 && "$MD_VERSION" == '3.0' ]]; then pip install -r requirements/lint_requirements.txt ; fi
+- if [[ `python -V | grep -c -e 3.6` -eq 1 && "$MD_VERSION" == '3.0' ]]; then pip install -r requirements/doc_requirements.txt ; fi
 - pip install -r requirements/test_requirements.txt
 - pip install codecov pytest-travis-fold
 - pip install -q "Markdown>=$MD_VERSION,<$MD_NEXT"
@@ -41,6 +42,7 @@ before_script:
 - pip freeze
 script:
 - if [[ `python -V | grep -c -e 3.7` -eq 1 && "$MD_VERSION" == '3.0' ]]; then flake8 . ; fi
+- if [[ `python -V | grep -c -e 3.6` -eq 1 && "$MD_VERSION" == '3.0' ]]; then cd docs && sphinx-build -W -b html -d _build/doctrees . _build/html; cd .. ; fi
 - pytest -v --cov --cov-report term-missing
 after_success:
 - codecov

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,13 +2,15 @@
 History
 =======
 
-Next Version!
--------------
+2.1.1 (2018-10-09)
+------------------
+- (Re-)Enable short-name module reference
+  (specific to Markdown v3; PR `#45`_)
 - Write documentation in Sphinx
 - Integrate Read The Docs
-- Rework existing restructured text documents
-- Fix badges in Read Me
+- Update badges in Read Me
 
+.. _#45: https://github.com/jambonrose/markdown_superscript_extension/pull/45
 
 2.1.0 (2018-10-07)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,6 @@ provided in full in the LICENSE file.
 
 Please read `the documentation`_ for more information.
 
-.. _`Python Markdown`: https://pypi.python.org/pypi/Markdown
+.. _`Python Markdown`: https://pypi.org/project/Markdown/
 .. _`Simplified (2 Clause) BSD license`: http://choosealicense.com/licenses/bsd-2-clause/
 .. _`the documentation`: https://markdown-superscript-extension.readthedocs.io/en/latest/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,7 +94,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ author = "Andrew Pinkham"
 # The short X.Y version
 version = ""
 # The full version, including alpha/beta/rc tags
-release = "2.1.0"
+release = "2.1.1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ class CustomCheckCommand(CheckCommand):
 
 setup(
     name="MarkdownSuperscript",
-    version="2.1.0",  # PEP 440 Compliant Semantic Versioning
+    version="2.1.1",  # PEP 440 Compliant Semantic Versioning
     keywords=["text", "filter", "markdown", "html", "superscript"],
     description="Python-Markdown extension to allow for superscript text.",
     long_description=LONG_DESCRIPTION,

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,6 @@ setup(
     cmdclass={"check": CustomCheckCommand},
     py_modules=["mdx_superscript"],
     install_requires=["Markdown>=2.5,<3.1"],
-    test_suite="tests",
     tests_require=TESTS_REQUIRE,
     setup_requires=SETUP_REQUIRES_PYTEST_RUNNER,
     license="Simplified BSD License",


### PR DESCRIPTION
This could be seen as a new feature, and therefore warrant the v2.2.0 label. However, as this is actually about ensuring feature parity for this package across Markdown versions, I would argue previous behavior is actually a bug, which merits a bug-patch.