### PR TITLE
Fix deprecation warnings.

### DIFF
--- a/mdx_superscript.py
+++ b/mdx_superscript.py
@@ -30,10 +30,7 @@ def makeExtension(*args, **kwargs):  # noqa: N802
 class SuperscriptExtension(Extension):
     """Extension: text between ^ characters will be superscripted."""
 
-    def extendMarkdown(self, md, md_globals):  # noqa: N802
-        """Insert 'superscript' pattern before 'not_strong' pattern."""
-        md.inlinePatterns.add(
-            "superscript",
-            SimpleTagPattern(SUPERSCRIPT_RE, "sup"),
-            "<not_strong",
-        )
+    def extendMarkdown(self, md):  # noqa: N802
+        """Insert 'superscript' pattern."""
+        # Priority of 75 corresponds to a place before the not_strong pattern
+        md.inlinePatterns.register(SimpleTagPattern(SUPERSCRIPT_RE, "sup"), "superscript", 75)


### PR DESCRIPTION
This PR fixes some DeprecationWarnings when using a recent version of Markdown (and such warnings are enabled using `-W always::DeprecationWarning`).

```
DeprecationWarning: Using the add method to register a processor or pattern is deprecated. Use the `register` method instead.
  md.inlinePatterns.add(
```

```
DeprecationWarning: The 'md_globals' parameter of 'mdx_superscript.SuperscriptExtension.extendMarkdown' is deprecated.
  ext._extendMarkdown(self)
```

See https://python-markdown.github.io/extensions/api/#registries for more info.